### PR TITLE
Fixed a bug with rapidjson keys found on ubuntu/gcc

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,19 +1,19 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.10
 
-COPY / /project_root
-ENV LIB_CPP_BUILD_DIR=/project_root/lib_cpp_build
 RUN apt-get -y upgrade
 RUN apt-get -y update
-RUN apt-get -y install clang-8
 RUN apt-get -y install curl wget git gnupg2
-#RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get -y install nodejs
 RUN apt-get -y install python3-pip
 RUN pip3 install cmake
 RUN wget -qO- --show-progress --progress=bar:force \
-    https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar xvz -C /usr/local
+    https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz | tar xvz -C /usr/local
 ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/.go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+COPY / /project_root
+
+ENV LIB_CPP_BUILD_DIR=/project_root/lib_cpp/build
 RUN mkdir $LIB_CPP_BUILD_DIR && cd $LIB_CPP_BUILD_DIR && \
     cmake /project_root/lib_cpp && \
     cmake --build . --target taraxa_evm_tests -j $(nproc --all)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-stack/stack v1.8.0
 	github.com/golang/protobuf v1.3.1
 	github.com/hashicorp/golang-lru v0.5.1
+	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v1.0.0
 	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c
 	golang.org/x/net v0.0.0-20190327214358-63eda1eb0650

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/allegro/bigcache v1.2.0/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2uc
 github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740 h1:FD4/ikKOFxwP8muWDypbmBWc634+YcAs3eBrYAmRdZY=
 github.com/aristanetworks/goarista v0.0.0-20190325233358-a123909ec740/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -21,6 +23,11 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/lib_cpp/CMakeLists.txt
+++ b/lib_cpp/CMakeLists.txt
@@ -9,10 +9,10 @@ include(FetchContent)
 set(SRC_DIR ${PROJECT_SOURCE_DIR}/src)
 set(ROOT_DIR ${PROJECT_SOURCE_DIR}/..)
 set(GO_MAIN_PACKAGE ${ROOT_DIR}/main)
-set(CGO_LIB_DEST ${CMAKE_CURRENT_BINARY_DIR}/taraxa_evm_cgo)
-set(CGO_LIB_FILE ${CGO_LIB_DEST}/taraxa_evm_cgo.a)
+set(CGO_LIB_DEST ${CMAKE_CURRENT_BINARY_DIR}/taraxa_evm)
+set(CGO_LIB_FILE ${CGO_LIB_DEST}/taraxa_evm_cgo/taraxa_evm_cgo.a)
 
-set(FETCHCONTENT_BASE_DIR ${PROJECT_SOURCE_DIR}/thirdparty)
+set(FETCHCONTENT_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thirdparty)
 set(FETCHCONTENT_QUIET OFF)
 
 macro(git_dependency name repo tag)
@@ -32,7 +32,7 @@ git_dependency(rapidjson_project https://github.com/Tencent/rapidjson v1.1.0 .)
 git_dependency(googletest_project https://github.com/google/googletest release-1.8.0 .)
 
 foreach (p boost_cmake googletest_project)
-    add_subdirectory(${${p}_SOURCE_DIR} EXCLUDE_FROM_ALL)
+    add_subdirectory(${${p}_SOURCE_DIR} ${FETCHCONTENT_BASE_DIR}/__builds__/${p} EXCLUDE_FROM_ALL)
 endforeach (p)
 
 add_custom_target(

--- a/lib_cpp/README.md
+++ b/lib_cpp/README.md
@@ -10,7 +10,7 @@
 - cmake 3.13+
 - C++17-compatible compiler
 
-The library has header dependencies on `rapidjson` and `boost`.
+The library has header dependencies on `rapidjson v1.1.0` and `boost v1.67.0`.
 It installs them on it's own: downloads from github and builds from source.
 It's straightforward to use the library in Cmake builds: just add this directory as
 Cmake subdirectory, and link against `taraxa_evm` library target. It will add header dependencies
@@ -20,6 +20,9 @@ search path.
 You can use your own versions of those, or reuse the paths installed by the library:
 - `THIS_DIR/thirdparty/boost-cmake-src/boost/boost_1_67_0`
 - `THIS_DIR/thirdparty/rapidjson-project-src/include`
+
+#### Notes
+- [Don't use boost 1.69](https://stackoverflow.com/questions/54911422/are-some-libraries-in-boost-1-69-not-compatible-with-macos)
 
 ### Building
 - Choose *any* build directory, let's call it BUILD_DIR

--- a/lib_cpp/src/lib.cpp
+++ b/lib_cpp/src/lib.cpp
@@ -1,5 +1,5 @@
 extern "C" {
-#include "taraxa_evm_cgo.h"
+#include "taraxa_evm_cgo/taraxa_evm_cgo.h"
 }
 
 #include "taraxa_evm/cgo_bridge.hpp"

--- a/lib_cpp/src/tests.cpp
+++ b/lib_cpp/src/tests.cpp
@@ -1,5 +1,3 @@
-#include <functional>
-#include <iostream>
 #include <gtest/gtest.h>
 #include "taraxa_evm/util_str.hpp"
 #include "taraxa_evm/util_io.hpp"
@@ -13,15 +11,17 @@ using namespace taraxa_evm::util_io;
 
 TEST(typed_api, create_contract) {
     LDBConfig ldbConfig{
-            .file = createFreshTmpDir("test_typed_api_create_contract")
+            createFreshTmpDir("test_typed_api_create_contract"),
+            0,
+            0
     };
     Block block{
-            .gasLimit = 100000000000,
-            .difficulty = 0,
-            .time = 0,
-            .number = 0,
-            .hash = "0x0000000000000000000000000000000000000000000000000000000000000000",
-            .coinbase = "0x0000000000000000000000000000000000000064",
+            "0x0000000000000000000000000000000000000064",
+            0,
+            0,
+            0,
+            100000000000,
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
     };
     string contractCode = "0x6080604052600560005534801561001557600080fd5b5060a2806100246000396000f3fe6080604052348015"
                           "600f57600080fd5b506004361060325760003560e01c806360fe47b11460375780636d4ce63c146053575b6000"
@@ -30,23 +30,23 @@ TEST(typed_api, create_contract) {
                           "4edea0ac59876c8ca6aaffd5b3f22379330029";
     vector<Transaction> transactions{
             Transaction{
-                    .nonce = 0,
-                    .from = "0x0000000000000000000000000000000000000064",
-                    .to = nullptr,
-                    .data = &contractCode,
-                    .amount= 0,
-                    .gasPrice= 0,
-                    .gasLimit= 100000000,
+                    "0x0000000000000000000000000000000000000064",
+                    nullptr,
+                    0,
+                    0,
+                    100000000,
+                    0,
+                    &contractCode,
             }
     };
     auto result = runEvm(RunConfiguration{
-            .stateRoot = "0x0000000000000000000000000000000000000000000000000000000000000000",
-            .block = &block,
-            .transactions = &transactions,
-            .ldbConfig = &ldbConfig,
-            .concurrentSchedule = nullptr
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            &block,
+            &transactions,
+            &ldbConfig,
+            nullptr
     }, ExternalApi{
-            .getHeaderHashByBlockNumber = [](auto i) {
+            [](auto i) {
                 return "fooo";
             }
     });

--- a/main/cgo_exports.go
+++ b/main/cgo_exports.go
@@ -17,7 +17,7 @@ import (
 func RunEvm(input *C.char, externalApi *C.ExternalApi) *C.char {
 	runConfig := new(state_transition.RunConfiguration)
 	err := json.Unmarshal([]byte(C.GoString(input)), runConfig)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 	result, _ := state_transition.Run(runConfig, &state_transition.ExternalApi{
 		GetHeaderHashByBlockNumber: func(n uint64) common.Hash {
 			c_str := C.getHeaderHashByBlockNumber(externalApi, C.uint64_t(n))
@@ -25,7 +25,7 @@ func RunEvm(input *C.char, externalApi *C.ExternalApi) *C.char {
 		},
 	})
 	bytes, err := json.Marshal(&result)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 	return C.CString(string(bytes))
 }
 

--- a/main/state_transition/state_processor_test.go
+++ b/main/state_transition/state_processor_test.go
@@ -75,7 +75,7 @@ contract SingleVariable {
 			&contractCreatingTx2,
 		},
 	}, externalApi)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 
 	assert.True(t, len(result1.ConcurrentSchedule.Sequential) == 0)
 
@@ -113,7 +113,7 @@ contract SingleVariable {
 			},
 		},
 	}, externalApi)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 
 	assert.Equal(t, result2.ConcurrentSchedule.Sequential, []conflict_tracking.TxId{1, 2})
 }
@@ -126,7 +126,7 @@ func addr(n int64) *common.Address {
 
 func compile(contract string) *compiler.Contract {
 	contracts, err := compiler.CompileSolidityString("solc", contract);
-	util.FailOnErr(err)
+	util.PanicOn(err)
 	for _, contract := range contracts {
 		return contract
 	}
@@ -136,31 +136,31 @@ func compile(contract string) *compiler.Contract {
 func code(contract *compiler.Contract) *hexutil.Bytes {
 	var code hexutil.Bytes
 	code, err := hexutil.Decode(contract.Code)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 	return &code
 }
 
 func call(contract *compiler.Contract, method string, args ...interface{}) *hexutil.Bytes {
 	var calldata hexutil.Bytes
 	calldata, err := contract.Info.AbiDefinition.Pack(method, args...)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 	return &calldata;
 }
 
 func newTestLDB() (LDBConfig, func()) {
 	dirname := "__test_ldb__"
 	if _, err := os.Stat(dirname); !os.IsNotExist(err) {
-		util.FailOnErr(os.RemoveAll(dirname))
+		util.PanicOn(os.RemoveAll(dirname))
 	}
-	util.FailOnErr(os.Mkdir(dirname, os.ModePerm))
+	util.PanicOn(os.Mkdir(dirname, os.ModePerm))
 	absPath, err := filepath.Abs(dirname)
-	util.FailOnErr(err)
+	util.PanicOn(err)
 	return LDBConfig{
 		File:    absPath,
 		Cache:   0,
 		Handles: 0,
 	}, func() {
-		util.FailOnErr(os.RemoveAll(dirname))
+		util.PanicOn(os.RemoveAll(dirname))
 	}
 }
 

--- a/main/util/errors.go
+++ b/main/util/errors.go
@@ -1,16 +1,21 @@
 package util
 
-func RecoverErr(callback func(error)) {
+import (
+	"errors"
+	"runtime/debug"
+)
+
+func Catch(callback func(error)) {
 	if recovered := recover(); recovered != nil {
 		if err, isErr := recovered.(error); isErr {
-			callback(err)
+			callback(errors.New(err.Error() + ". Stack trace:\n" + string(debug.Stack())))
 		} else {
 			panic(recovered)
 		}
 	}
 }
 
-func FailOnErr(err error) {
+func PanicOn(err error) {
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The bug caused duplicate keys in the constructed json string.
The fix was to explicitly allocate rapidjson objects for the key strings.

Beyond that:
- Refactored some code
- Added some notes in the docs
- Made a proper ubuntu docker image