### PR TITLE
DPOS fixes

### DIFF
--- a/taraxa/state/dpos/api.go
+++ b/taraxa/state/dpos/api.go
@@ -20,7 +20,15 @@ type Config = struct {
 	EligibilityBalanceThreshold *big.Int
 	DepositDelay                types.BlockNum
 	WithdrawalDelay             types.BlockNum
-	GenesisState                Addr2Addr2Balance
+	GenesisState                []GenesisStateEntry
+}
+type GenesisStateEntry = struct {
+	Benefactor common.Address
+	Transfers  []GenesisTransfer
+}
+type GenesisTransfer = struct {
+	Beneficiary common.Address
+	Value       *big.Int
 }
 
 func (self *API) Init(cfg Config) *API {

--- a/taraxa/state/dpos/storage.go
+++ b/taraxa/state/dpos/storage.go
@@ -49,6 +49,7 @@ func (self *StorageReaderWrapper) Get(k *common.Hash, cb func([]byte)) {
 		if self.cache == nil {
 			self.cache = make(map[common.Hash][]byte)
 		}
+		bytes = common.CopyBytes(bytes)
 		self.cache[*k] = bytes
 		cb(bytes)
 	})

--- a/taraxa/state/dpos/test_integration/framework.go
+++ b/taraxa/state/dpos/test_integration/framework.go
@@ -97,13 +97,15 @@ func (self *Spec) run(t *testing.T) {
 	chain_cfg.DPOS.DepositDelay = self.DposCfg.DepositDelay
 	chain_cfg.DPOS.EligibilityBalanceThreshold = new(big.Int).SetInt64(int64(
 		self.DposCfg.EligibilityBalanceThreshold))
-	chain_cfg.DPOS.GenesisState = make(dpos.Addr2Addr2Balance)
 	for k, v := range self.DposCfg.DposGenesisState {
-		v_mapped := make(dpos.Addr2Balance)
+		entry := dpos.GenesisStateEntry{Benefactor: k}
 		for k1, v1 := range v {
-			v_mapped[k1] = new(big.Int).SetInt64(int64(v1))
+			entry.Transfers = append(entry.Transfers, dpos.GenesisTransfer{
+				Beneficiary: k1,
+				Value:       new(big.Int).SetInt64(int64(v1)),
+			})
 		}
-		chain_cfg.DPOS.GenesisState[k] = v_mapped
+		chain_cfg.DPOS.GenesisState = append(chain_cfg.DPOS.GenesisState, entry)
 	}
 
 	statedb := new(state_db_rocksdb.DB).Init(state_db_rocksdb.Opts{


### PR DESCRIPTION
1) Fixed random byte buffer corruption in dpos contract
2) Because DPOS contract is sensitive to the order of transfers (described in a DPOS transaction), it was not appropriate to use a hash map to represent those transfers because it doesn't maintain insertion order. I switched to arrays of key/value tuples instead of hashmaps in some places.
3) Some cosmetic improvements