### PR TITLE
chore: prune light node

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -37,6 +37,8 @@ const (
 	HashLength = 32
 	// AddressLength is the expected length of the address
 	AddressLength = 20
+	// VersionedKeyLength is the expected length of the versioned key
+	VersionedKeyLength = 40
 )
 
 var (

--- a/taraxa/C/state.go
+++ b/taraxa/C/state.go
@@ -362,6 +362,22 @@ func taraxa_evm_state_api_db_snapshot(
 	util.PanicIfNotNil(db.Snapshot(dir, log_size_for_flush))
 }
 
+//export taraxa_evm_state_api_prune
+func taraxa_evm_state_api_prune(
+	ptr C.taraxa_evm_state_API_ptr,
+	params_enc C.taraxa_evm_Bytes,
+	cb_err C.taraxa_evm_BytesCallback,
+) {
+	defer handle_err(cb_err)
+	var params struct {
+		StateRootToKeep  common.Hash
+		StateRootToPrune []common.Hash
+		BlkNum           types.BlockNum
+	}
+	dec_rlp(params_enc, &params)
+	state_API_instances[ptr].db.Prune(params.StateRootToKeep, params.StateRootToPrune, params.BlkNum)
+}
+
 type state_API_ptr = byte
 
 const state_API_max_instances = ^state_API_ptr(0)

--- a/taraxa/state/state_db/block_reader.go
+++ b/taraxa/state/state_db/block_reader.go
@@ -55,6 +55,31 @@ func (self ExtendedReader) ForEachStorage(addr *common.Address, f func(*common.H
 	})
 }
 
+func (self ExtendedReader) ForEachAccountNodeHashByRoot(storage_root *common.Hash, f func(*common.Hash)) {
+	if storage_root == nil {
+		return
+	}
+	no_addr := common.Address{}
+	trie.Reader{AccountTrieSchema{}}.ForEachNodeHash(
+		AccountTrieInputAdapter{&no_addr, self},
+		storage_root,
+		func(hash *common.Hash) {
+			f(hash)
+		})
+}
+
+func (self ExtendedReader) ForEachMainNodeHashByRoot(storage_root *common.Hash, f func(*common.Hash)) {
+	if storage_root == nil {
+		return
+	}
+	trie.Reader{MainTrieSchema{}}.ForEachNodeHash(
+		MainTrieInputAdapter{self},
+		storage_root,
+		func(hash *common.Hash) {
+			f(hash)
+		})
+}
+
 type Proof struct {
 	AccountProof  trie.Proof
 	StorageProofs []trie.Proof


### PR DESCRIPTION
Added method prune which deletes all the old data from the state_db for all blocks that are not kept under the light node history