### PR TITLE
feat: add delegators set to validators and method to get it

### DIFF
--- a/taraxa/state/dpos/precompiled/validators.go
+++ b/taraxa/state/dpos/precompiled/validators.go
@@ -32,6 +32,17 @@ type Validator struct {
 
 	// Block number pointing to latest state
 	LastUpdated types.BlockNum
+
+	// Set of delegators
+	Delegators map[common.Address]struct{}
+}
+
+func (self *Validator) AddDelegator(delegator *common.Address) {
+	self.Delegators[*delegator] = struct{}{}
+}
+
+func (self *Validator) RemoveDelegator(delegator *common.Address) {
+	delete(self.Delegators, *delegator)
 }
 
 type ValidatorInfo struct {
@@ -168,6 +179,7 @@ func (self *Validators) CreateValidator(owner_address *common.Address, validator
 	rewards_key := stor_k_1(self.validator_rewards_field, validator_address[:])
 	self.storage.Put(rewards_key, rlp.MustEncodeToBytes(rewards))
 
+	validator.Delegators = make(map[common.Address]struct{})
 	// Adds validator into the list of all validators
 	self.validators_list.CreateAccount(validator_address)
 	return validator

--- a/taraxa/state/dpos/tests/dpos_test.go
+++ b/taraxa/state/dpos/tests/dpos_test.go
@@ -94,6 +94,27 @@ func TestDelegateMinMax(t *testing.T) {
 	test.ExecuteAndCheck(addr(2), DefaultMinimumDeposit, test.pack("delegate", val_addr), util.ErrorString(""), util.ErrorString(""))
 }
 
+func TestValidatorDelegations(t *testing.T) {
+	tc, test := init_test(t, CopyDefaultChainConfig())
+	defer test.end()
+
+	val_addr, proof := generateAddrAndProof()
+	test.ExecuteAndCheck(addr(1), DefaultMinimumDeposit, test.pack("registerValidator", val_addr, proof, DefaultVrfKey, uint16(10), "test", "test"), util.ErrorString(""), util.ErrorString(""))
+	count := 3
+	for i := 0; i < count; i++ {
+		test.ExecuteAndCheck(addr(uint64(i+1)), DefaultMinimumDeposit, test.pack("delegate", val_addr), util.ErrorString(""), util.ErrorString(""))
+	}
+
+	validator_delegators_raw := test.ExecuteAndCheck(addr(1), big.NewInt(0), test.pack("getValidatorDelegators", val_addr), util.ErrorString(""), util.ErrorString(""))
+	validator_delegators := []common.Address{}
+	test.unpack(&validator_delegators, "getValidatorDelegators", validator_delegators_raw.CodeRetval)
+	tc.Assert.Equal(count, len(validator_delegators))
+
+	for i := 0; i < count; i++ {
+		tc.Assert.Equal(addr(uint64(i+1)), validator_delegators[i])
+	}
+}
+
 func TestRedelegate(t *testing.T) {
 	tc, test := init_test(t, CopyDefaultChainConfig())
 	defer test.end()


### PR DESCRIPTION
Add set of delegators to validator object. This changes with total stake and some other fields, so validator object is definitely a proper place for it 
Should be merged with #140 to reduce state_db size