### PR TITLE
fix: remove getValidatorDelegators from solidity interface

### DIFF
--- a/taraxa/state/dpos/solidity/dpos_contract_interface.sol
+++ b/taraxa/state/dpos/solidity/dpos_contract_interface.sol
@@ -146,11 +146,6 @@ interface DposInterface {
         view
         returns (ValidatorBasicInfo memory validator_info);
 
-    // Returns validator delegators list
-    function getValidatorDelegators(address validator)
-        external
-        view
-        returns (address[] memory delegators);
     /**
      * @notice Returns list of registered validators
      *


### PR DESCRIPTION
Remove getValidatorDelegators from dpos contract solidity interface 