### PR TITLE
chore: remove jail compound time

### DIFF
--- a/taraxa/state/contracts/slashing/precompiled/slashing_contract.go
+++ b/taraxa/state/contracts/slashing/precompiled/slashing_contract.go
@@ -278,11 +278,6 @@ func (self *Contract) jailValidator(current_block types.BlockNum, validator *com
 		rlp.MustDecodeBytes(bytes, currrent_jail_block)
 	})
 
-	// In case validator is already jailed, compound his jail time
-	if currrent_jail_block != nil && *currrent_jail_block+self.cfg.JailTime > jail_block {
-		jail_block = *currrent_jail_block + self.cfg.JailTime
-	}
-
 	self.storage.Put(db_key, rlp.MustEncodeToBytes(jail_block))
 
 	// This will be run just once after first write

--- a/taraxa/state/contracts/tests/slashing/slashing_test.go
+++ b/taraxa/state/contracts/tests/slashing/slashing_test.go
@@ -295,7 +295,7 @@ func TestGetJailBlock(t *testing.T) {
 	result = test.ExecuteAndCheck(proof_author, big.NewInt(0), test.Pack("getJailBlock", malicious_vote_author1), util.ErrorString(""), util.ErrorString(""))
 	result_parsed = new(uint64)
 	test.Unpack(result_parsed, "getJailBlock", result.CodeRetval)
-	tc.Assert.Equal(1+2*DefaultChainCfg.Hardforks.MagnoliaHf.JailTime, *result_parsed)
+	tc.Assert.Equal(1+2*uint64(test.Chain_cfg.DPOS.DelegationDelay)+DefaultChainCfg.Hardforks.MagnoliaHf.JailTime, *result_parsed)
 }
 
 func TestMakeLogsCheckTopics(t *testing.T) {


### PR DESCRIPTION
If we do compounding a user that accidentally started two nodes might get jailed for a very long time if it keeps double voting